### PR TITLE
fixes #10 ステータスバー半透過の裏にある画面の下部にパディングを追加する

### DIFF
--- a/app/src/main/java/jp/co/crowdworks/android/nasulog/view/NavigationLinearLayout.java
+++ b/app/src/main/java/jp/co/crowdworks/android/nasulog/view/NavigationLinearLayout.java
@@ -1,0 +1,7 @@
+package jp.co.crowdworks.android.nasulog.view;
+
+/**
+ * Created by YusukeIwaki on 2016/01/30.
+ */
+public class NavigationLinearLayout {
+}

--- a/app/src/main/res/layout/compose_poem_screen.xml
+++ b/app/src/main/res/layout/compose_poem_screen.xml
@@ -3,11 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/status_bar_height"
-        android:background="@color/colorPrimary"/>
+    android:layout_height="match_parent"
+    style="@style/FitToSystemWindow">
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
@@ -20,7 +17,8 @@
     <android.support.v4.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0px"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        android:background="@color/light_background">
 
         <FrameLayout
             android:layout_width="match_parent"
@@ -62,8 +60,4 @@
             </LinearLayout>
         </FrameLayout>
     </android.support.v4.widget.NestedScrollView>
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/nav_bar_height"
-        android:background="@color/colorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/layout/compose_poem_screen.xml
+++ b/app/src/main/res/layout/compose_poem_screen.xml
@@ -62,4 +62,8 @@
             </LinearLayout>
         </FrameLayout>
     </android.support.v4.widget.NestedScrollView>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/nav_bar_height"
+        android:background="@color/colorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/layout/partial_poem_detail.xml
+++ b/app/src/main/res/layout/partial_poem_detail.xml
@@ -4,8 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorPrimary"
-    android:fitsSystemWindows="true">
+    style="@style/FitToSystemWindow">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/partial_poem_list.xml
+++ b/app/src/main/res/layout/partial_poem_list.xml
@@ -4,8 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/colorPrimary"
-    android:fitsSystemWindows="true">
+    style="@style/FitToSystemWindow">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/simple_webview.xml
+++ b/app/src/main/res/layout/simple_webview.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical">
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/status_bar_height"
-        android:background="@color/colorPrimary"/>
+    android:orientation="vertical"
+    style="@style/FitToSystemWindow">
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar_webview"
         android:layout_width="match_parent"
@@ -22,9 +19,4 @@
         android:layout_width="match_parent"
         android:layout_height="0px"
         android:layout_weight="1"/>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/nav_bar_height"
-        android:background="@color/colorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/layout/simple_webview.xml
+++ b/app/src/main/res/layout/simple_webview.xml
@@ -22,4 +22,9 @@
         android:layout_width="match_parent"
         android:layout_height="0px"
         android:layout_weight="1"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/nav_bar_height"
+        android:background="@color/colorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/values-v19/dimens.xml
+++ b/app/src/main/res/values-v19/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="status_bar_height">24dp</dimen>
+    <dimen name="nav_bar_height">48dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="status_bar_height">0dp</dimen>
+    <dimen name="nav_bar_height">0dp</dimen>
     <dimen name="dummy_footer_height">128dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,6 +14,11 @@
         <item name="windowActionModeOverlay">true</item>
     </style>
 
+    <style name="FitToSystemWindow">
+        <item name="android:background">@color/colorPrimary</item>
+        <item name="android:fitsSystemWindows">true</item>
+    </style>
+
     <style name="PoemCard">
         <item name="android:background">@drawable/card_background</item>
         <item name="android:paddingTop">10dp</item>


### PR DESCRIPTION
## 原因

https://github.com/CWPoemDev/nasulog_android/blob/ea1a78637e6a903b374799096ea86aaa15e0323b/app/src/main/res/values/styles.xml#L12
で、しれっとステータスバーを半透過にした。その結果、レイアウト領域がナビゲーションバーの裏まで含まれるようになり、下のほうが押せない画面がいくつか出てきてしまった。
## 対処

`android:fitsSystemWindows="true"` を設定して大丈夫なものはそれをセットする。
微妙なものは、ナビゲーションバー分のpaggindをたす
