### PR TITLE
fixes #9 ナビゲーションメニューの幅を修正

### DIFF
--- a/app/src/main/java/jp/co/crowdworks/android/nasulog/view/NavigationLinearLayout.java
+++ b/app/src/main/java/jp/co/crowdworks/android/nasulog/view/NavigationLinearLayout.java
@@ -1,7 +1,45 @@
 package jp.co.crowdworks.android.nasulog.view;
 
-/**
- * Created by YusukeIwaki on 2016/01/30.
- */
-public class NavigationLinearLayout {
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.LinearLayout;
+
+public class NavigationLinearLayout extends LinearLayout {
+    private int mMaxWidth;
+
+    public NavigationLinearLayout(Context context) {
+        super(context);
+        setMaxWidth(context);
+    }
+
+    public NavigationLinearLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setMaxWidth(context);
+    }
+
+    public NavigationLinearLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        setMaxWidth(context);
+    }
+
+    private void setMaxWidth(Context context) {
+        mMaxWidth = context.getResources().getDimensionPixelSize(android.support.design.R.dimen.design_navigation_max_width);
+    }
+
+
+    @Override
+    protected void onMeasure(int widthSpec, int heightSpec) {
+        switch (MeasureSpec.getMode(widthSpec)) {
+            case MeasureSpec.EXACTLY:
+            case MeasureSpec.AT_MOST:
+                widthSpec = MeasureSpec.makeMeasureSpec(
+                        Math.min(MeasureSpec.getSize(widthSpec), mMaxWidth), MeasureSpec.EXACTLY);
+                break;
+            case MeasureSpec.UNSPECIFIED:
+                widthSpec = MeasureSpec.makeMeasureSpec(mMaxWidth, MeasureSpec.EXACTLY);
+                break;
+        }
+        // Let super sort out the height
+        super.onMeasure(widthSpec, heightSpec);
+    }
 }

--- a/app/src/main/res/layout/partial_drawer_menu.xml
+++ b/app/src/main/res/layout/partial_drawer_menu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<jp.co.crowdworks.android.nasulog.view.NavigationLinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_menu"
-    android:layout_width="280dp"
+    android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     android:background="#ffffff"
@@ -51,4 +51,4 @@
         android:layout_height="0px"
         android:layout_weight="1"
         android:theme="@style/Theme.AppCompat.Light"/>
-</LinearLayout>
+</jp.co.crowdworks.android.nasulog.view.NavigationLinearLayout>


### PR DESCRIPTION
ドロワーメニューをマテリアルデザイン（最大320dpまたは画面右から64dp）にしたがうものに変更する

実は別のプロジェクトでやったことがあるので、 [そこ](https://github.com/RocketChat/Rocket.Chat.Android.Lily/blob/8b1aa3489a189c2e7bdc79b975845303b01b2810/app/src/main/java/chat/rocket/android/view/NavigationLinearLayout.java)から実装をイタダキ
